### PR TITLE
Add pandas as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
   "earthengine-api>=0.1.374",
   "dask[dataframe]",
+  "pandas",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I am trying to add dask-ee to conda-forge. The testing failed becaused pandas is not included in the dependency list. We should add it. 

https://github.com/conda-forge/staged-recipes/pull/26760
![image](https://github.com/alxmrs/dask-ee/assets/5016453/03bce51f-449f-46cf-960f-d68ce107885a)
