### PR TITLE
Fix: Adding missing built-in dtype.

### DIFF
--- a/dask_ee/read.py
+++ b/dask_ee/read.py
@@ -12,6 +12,7 @@ _BUILTIN_DTYPES = {
     'Double': np.float64,
     'Float': np.float32,
     'Int': np.int32,
+    'Integer': np.int32,
     'Int16': np.int16,
     'Int32': np.int32,
     'Int64': np.int64,


### PR DESCRIPTION
Thanks to @chrowe for reporting this issue. It seems like I've overlooked an EE dtype when parsing their documentation.

Fixes #18.