### PR TITLE
Fix release pipeline: bump upload-artifact version to v4.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+
+
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           python -m twine check dist/*
           pwd
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: releases
           path: dist


### PR DESCRIPTION
See: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/